### PR TITLE
clear icon not visible

### DIFF
--- a/Src/MoneyManager.Windows/Views/ModifyTransactionView.xaml
+++ b/Src/MoneyManager.Windows/Views/ModifyTransactionView.xaml
@@ -103,10 +103,11 @@
                                 </core:EventTriggerBehavior>
                             </interactivity:Interaction.Behaviors>
                         </TextBox>
-                        <Image Source="/Assets/light/close.png"
+                        <Image Source="/Assets/dark/close.png"
                                Height="35"
                                VerticalAlignment="Bottom"
-                               HorizontalAlignment="Right">
+                               HorizontalAlignment="Right"
+                               Margin="0,0,0,-2">
                             <interactivity:Interaction.Behaviors>
                                 <core:EventTriggerBehavior EventName="Tapped">
                                     <core:InvokeCommandAction Command="{Binding ResetCategoryCommand, Mode=OneWay}" />


### PR DESCRIPTION
the icon for clearing the category selection wasn't visible due to the
wrong theme color staticly set.
#601
